### PR TITLE
Исправления .jq-file input

### DIFF
--- a/jquery.formstyler.css
+++ b/jquery.formstyler.css
@@ -66,6 +66,8 @@
 }
 .jq-file input {
 	cursor: pointer;
+	height: auto;
+	line-height: 1em;
 }
 .jq-file .name {
 	width: 170px;


### PR DESCRIPTION
При использовании сброса стилей, если указана конкретная высота и line-height у input[type="file"] инпут не растягивается до размера шрифта.
патч решает проблему.
