### PR TITLE
Исправил обработку спецсимволов для тэгов «select»

### DIFF
--- a/jquery.formstyler.js
+++ b/jquery.formstyler.js
@@ -565,7 +565,7 @@
 
 								// изменение селекта
 								el.change(function() {
-									divText.text(option.filter(':selected').text());
+									divText.html(option.filter(':selected').text());
 									li.removeClass('selected sel').not('.optgroup').eq(el[0].selectedIndex).addClass('selected sel');
 								})
 								.focus(function() {


### PR DESCRIPTION
В случае, если в тэге «select» в опциях прописаны escape-последовательности (например, &euro;) при изменении псевдо-элемента выводится код последовательности, а не готовый символ.
