### PR TITLE
trigger filter

### DIFF
--- a/jquery.formstyler.js
+++ b/jquery.formstyler.js
@@ -790,7 +790,8 @@
 								$(this)
 									.parent()
 									.find('li')
-									.show();
+									.show()
+									.removeClass('filter_hide');
 							}
 							else
 							{
@@ -815,7 +816,7 @@
 												{
 													$this.removeClass('filter_hide');
 												}
-												window.console.debug(result);
+												
 												return result;
 											}).show()
 									;


### PR DESCRIPTION
Фильтрация элементов по какому-то атрибуту. Фильтруются только списки сделанные плагином, оригинальные селекты не меняются. Пример. На странице два селекта. В первом типы, во втором связанные с ними элементы. Выбираем что-то в первом, нужно отфильтровать данные во втором. Именно для этого можно вызвать триггер с каким-то атрибутом имеющим нужное значение.
$('select.iodformstyler').trigger('filter', {'data-type': 2});
вернуть как было.
$('select.iodformstyler').trigger('filter', 'all');
