### PR TITLE
Устранил потенциальную утечку памяти

### DIFF
--- a/jquery.formstyler.js
+++ b/jquery.formstyler.js
@@ -152,6 +152,7 @@
 
 				// обновление при динамическом изменении
 				el.on('refresh', function() {
+					el.closest('label').add('label[for="' + el.attr('id') + '"]').off('.styler');
 					el.off('.styler').parent().before(el).remove();
 					checkboxOutput();
 				});
@@ -221,6 +222,7 @@
 
 				// обновление при динамическом изменении
 				el.on('refresh', function() {
+					el.closest('label').add('label[for="' + el.attr('id') + '"]').off('.styler');
 					el.off('.styler').parent().before(el).remove();
 					radioOutput();
 				});


### PR DESCRIPTION
В [релиз 1.7.3](https://github.com/Dimox/jQueryFormStyler/commit/572d18d91f96e3fe40a0b7cd91310a8d2884ddc1) добавлены изменения из пулл-реквеста #82, но без этих двух строк. Есть ли на то какая-то веская причина?