### PR TITLE
Ошибка отображения плейсхолдера при заданном тексте опции

### DIFF
--- a/jquery.formstyler.js
+++ b/jquery.formstyler.js
@@ -498,7 +498,7 @@
 
 						// показываем опцию по умолчанию
 						// если 1-я опция пустая и выбрана по умолчанию, то показываем плейсхолдер
-						if (el.val() === '') {
+						if (optionSelected.text() === '') {
 							divText.text(selectPlaceholder).addClass('placeholder');
 						} else {
 							divText.text(optionSelected.text());


### PR DESCRIPTION
В значении по умолчанию может быть записано что-то другое, например 0. Если же для пустого значения задан текст, плейсхолдер так же не нужен. Поэтому нужно проверять, что выбранный элемент пуст, и в этом случае показывать плейсхолдер.