### PR TITLE
prevent click event when select tag has disabled parameter

### DIFF
--- a/jquery.formstyler.js
+++ b/jquery.formstyler.js
@@ -580,6 +580,8 @@
 						// при клике на псевдоселекте
 						divSelect.click(function() {
 
+							if (el.hasAttr('disabled')) return;
+
 							// колбек при закрытии селекта
 							if ($('div.jq-selectbox').filter('.opened').length) {
 								opt.onSelectClosed.call($('div.jq-selectbox').filter('.opened'));


### PR DESCRIPTION
Недопустимо открытие псевдо-селекта, когда сам тег select имеет атрибут "disabled"