### PR TITLE
CSS облегечения для пользователей селекта

### DIFF
--- a/jquery.formstyler.css
+++ b/jquery.formstyler.css
@@ -272,6 +272,7 @@
 	width: 100%;
 	white-space: nowrap;
 	text-overflow: ellipsis;
+	user-select: none;
 }
 .jq-selectbox .placeholder {
 	color: #888;
@@ -336,6 +337,7 @@
 	padding: 5px 8px 6px;
 	background: #F0F0F0;
 	font-size: 13px;
+	user-select: none;
 }
 .jq-selectbox ul {
 	margin: 0;

--- a/jquery.formstyler.css
+++ b/jquery.formstyler.css
@@ -353,6 +353,7 @@
 	white-space: nowrap;
 	color: #231F20;
 }
+.jq-selectbox li.sel,
 .jq-selectbox li.selected {
 	background-color: #A3ABB1;
 	color: #FFF;

--- a/jquery.formstyler.css
+++ b/jquery.formstyler.css
@@ -272,7 +272,10 @@
 	width: 100%;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-	user-select: none;
+	-webkit-user-select: none;
+	   -moz-user-select: none;
+	    -ms-user-select: none;
+	        user-select: none;
 }
 .jq-selectbox .placeholder {
 	color: #888;
@@ -337,7 +340,10 @@
 	padding: 5px 8px 6px;
 	background: #F0F0F0;
 	font-size: 13px;
-	user-select: none;
+	-webkit-user-select: none;
+	   -moz-user-select: none;
+	    -ms-user-select: none;
+	        user-select: none;
 }
 .jq-selectbox ul {
 	margin: 0;


### PR DESCRIPTION
[**d36ad42**](https://github.com/yunusga/jQueryFormStyler/commit/d36ad42478da5f7d831fa542ec5d0bea6fa0fc90) - отключил выделение текста на кнопке селекта, на случай если человек с тач-устройством задержится на ней надолго, что приведёт к открытию диалога копирования текста с кнопки (зачем совершать лишние действия?!)
[**d5d3df0**](https://github.com/yunusga/jQueryFormStyler/commit/d5d3df0b0f192f7f6715ef851f5c34bbb5718add) - выбранный пункт теперь всегда подсвечен, в предыдущем варианте выделенный пункт становился стандартным при попадании мыши в область списка, для нахождения выбранного пункта приходилось либо уводить мышь из области списка или догадаться подсмотреть наверх