### PR TITLE
Опция для размещения собственного HTML в jq-selectbox__trigger

### DIFF
--- a/jquery.formstyler.js
+++ b/jquery.formstyler.js
@@ -29,6 +29,7 @@
 				filePlaceholder: 'Файл не выбран',
 				fileBrowse: 'Обзор...',
 				fileNumber: 'Выбрано файлов: %s',
+				selectTriggerHtml: false,
 				selectPlaceholder: 'Выберите...',
 				selectSearch: false,
 				selectSearchLimit: 10,
@@ -536,12 +537,14 @@
 						if (singleSelectzIndex === undefined || singleSelectzIndex === '') singleSelectzIndex = opt.singleSelectzIndex;
 						if (selectSmartPositioning === undefined || selectSmartPositioning === '') selectSmartPositioning = opt.selectSmartPositioning;
 
+						var selectTriggerHtml = opt.selectTriggerHtml ? opt.selectTriggerHtml.toString() : '<div class="jq-selectbox__trigger-arrow"></div>';
 						var selectbox =
 							$('<div class="jq-selectbox jqselect">' +
 									'<div class="jq-selectbox__select" style="position: relative">' +
 										'<div class="jq-selectbox__select-text"></div>' +
 										'<div class="jq-selectbox__trigger">' +
-											'<div class="jq-selectbox__trigger-arrow"></div></div>' +
+											selectTriggerHtml +
+										'</div>' +
 									'</div>' +
 								'</div>')
 							.css({


### PR DESCRIPTION
Предлагаемый по умолчанию HTML для `jq-selectbox__trigger`, не всегда подходит для решения задач по стилизации этого элемента селекта. Проблемы начинаются когда необходимо вставить в него нечто не реализуемое на `CSS` с сменой цвета в зависимости от состояния селекта, а решение такой задачи с помощью `background` вызывает в дальнейшем трудности с темизацией и последующими правками по дизайну.