### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     "url": "https://github.com/Dimox/jQueryFormStyler/issues"
   },
   "homepage": "http://dimox.name/jquery-form-styler/",
-  "dependencies": {
-    "jquery": "^1.7.0"
-  },
   "devDependencies": {
     "browser-sync": "^2.18.8",
     "gulp": "^3.9.1",


### PR DESCRIPTION
When use npm, this package downloads into itself node_nodules/jquery (v1.12.4)
I use a different version of jquery, and when I require this plugin, my jquery redefines by this jquery.